### PR TITLE
Clear menu item position

### DIFF
--- a/menu.c
+++ b/menu.c
@@ -105,10 +105,12 @@ static void menumode_handler(void)
 
     } else if (ports_button_pressed(PORTS_BTN_UP, 0)) {
         menumode.item = menumode.item->next;
+        display_clear(0, 2);
         display_chars(0, LCD_SEG_L2_4_0, menumode.item->name, SEG_SET);
 
     } else if (ports_button_pressed(PORTS_BTN_DOWN, 0)) {
         menumode.item = menumode.item->prev;
+        display_clear(0, 2);
         display_chars(0, LCD_SEG_L2_4_0, menumode.item->name, SEG_SET);
     }
 }

--- a/modules/battery.c
+++ b/modules/battery.c
@@ -78,6 +78,6 @@ static void battery_deactivate(void)
 
 void mod_battery_init(void)
 {
-	menu_add_entry(" BATT", NULL, NULL, NULL, NULL, NULL, NULL,
+	menu_add_entry("BATT", NULL, NULL, NULL, NULL, NULL, NULL,
 		&battery_activate, &battery_deactivate);
 }

--- a/modules/otp.c
+++ b/modules/otp.c
@@ -310,7 +310,7 @@ static void otp_deactivated()
 
 void mod_otp_init()
 {
-    menu_add_entry("  OTP",
+    menu_add_entry("OTP",
         NULL,               /* up         */
         NULL,               /* down       */
         NULL,               /* num        */

--- a/modules/stopwatch.c
+++ b/modules/stopwatch.c
@@ -243,7 +243,7 @@ void mod_stopwatch_init(void) {
     sSwatch_conf.state = SWATCH_MODE_OFF;
     clear_stopwatch();
 
-    menu_entry = menu_add_entry(" STOP",
+    menu_entry = menu_add_entry("STOP",
                                 &up_press,
                                 &down_press,
                                 &num_press,

--- a/modules/temperature.c
+++ b/modules/temperature.c
@@ -108,7 +108,7 @@ static void temperature_edit(void)
 
 void mod_temperature_init(void)
 {
-	menu_add_entry(" TEMP",
+	menu_add_entry("TEMP",
 				   NULL,
 				   NULL,
 				   NULL,


### PR DESCRIPTION
Menu item name position is cleared before rendering new item's name so no more spaces needed. I think it's better solution.