### PR TITLE
Support multiple TOTP Secrets to be configured, the format of the fie…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ set(source_files
     modules/tide.c
     modules/temperature.c
     modules/clock.c
-    modules/sha1.c
+    modules/hashutils.c
     modules/otp.c
     modules/stopwatch.c
     modules/accelerometer.c

--- a/modules/hashutils.h
+++ b/modules/hashutils.h
@@ -1,4 +1,4 @@
-// SHA1 header file
+// SHA1/HMAC header file
 //
 // Copyright 2010 Google Inc.
 // Author: Markus Gutschke
@@ -15,9 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SHA1_H__
-#define SHA1_H__
-
+#pragma once
 #include <stdint.h>
 
 #define SHA1_BLOCKSIZE     64
@@ -36,4 +34,6 @@ __attribute__((visibility("hidden")));
 void sha1_final(SHA1_INFO *sha1_info, uint8_t digest[20])
 __attribute__((visibility("hidden")));
 
-#endif
+void hmac_sha1(const uint8_t *key, int keyLength,
+               const uint8_t *data, int dataLength,
+               uint8_t *result, int resultLength) __attribute__((visibility("hidden")));;

--- a/modules/otp.c
+++ b/modules/otp.c
@@ -145,7 +145,7 @@ static void clock_event(enum sys_message msg)
     display_bits(0, LCD_SEG_L2_4, indicator[2*segment  ], SEG_SET);
     display_bits(0, LCD_SEG_L2_4, indicator[2*segment+1], BLINK_SET);
     display_char(0 ,LCD_SEG_L1_3, otp_identifier, SEG_SET); 
-    display_char(0 ,LCD_SEG_L1_3, otp_identifier, BLINK_SET); 
+    display_char(0 ,LCD_SEG_L1_3, otp_identifier, BLINK_ON); 
 
     // Calculate timestamp
 	uint32_t time = simple_mktime(rtca_time.year, rtca_time.mon - 1, rtca_time.day,
@@ -180,7 +180,7 @@ static void otp_activated()
 static void otp_deactivated()
 {
     sys_messagebus_unregister_all(&clock_event);
-
+    display_char(0 ,LCD_SEG_L1_3, '8', BLINK_OFF); 
     /* clean up screen */
     display_clear(0, 1);
     display_clear(0, 2);

--- a/modules/otp.cfg
+++ b/modules/otp.cfg
@@ -5,8 +5,8 @@ default = false
 help = Enable OTP generation
 depends = CONFIG_RTC_IRQ
 
-[OTP_KEY]
-name = OTP Key
+[OTP_KEYS]
+name = OTP Keys
 type = text
 default =
 encoding = b32encode

--- a/modules/otp.h
+++ b/modules/otp.h
@@ -17,10 +17,10 @@
 
 #ifndef  __OTP_H__
 #define  __OTP_H__
-
 #include <stdint.h>
-
-void hmac_sha1(const uint8_t *key, int keyLength,
-               const uint8_t *data, int dataLength,
-               uint8_t *result, int resultLength);
+typedef struct keystore
+{
+    const  char *otp_identifier;
+    const  char *otp_key;
+}keystore_t;
 #endif

--- a/tools/field_encodings.py
+++ b/tools/field_encodings.py
@@ -5,13 +5,50 @@
 import base64
 import time
 
-def b32encode(string, encode):
-	if encode:
+def b32encode_each(string, decode):
+	if decode:
 		key = base64.b32decode(string.upper().replace(" ",""))
 		return  '"' + "".join(map(lambda x:"\\x%02x" % ord(x), list(key))) + '"'
 	else:
 		s =  "".join(map (lambda x: chr(int("0x" + x, 16)), string.replace('"', '').split("\\x")[1:]))
 		return  base64.b32encode(s)
+
+def b32encode(strings, decode):
+        strings.strip()
+        start_block = '{ '
+        end_block= ' }'
+        removechars = start_block + end_block + ' '
+        if decode:
+            encoded_auth_secrets = strings.split(',')
+            encoded_auth_list = []
+            for encoded_auth_count, secret in enumerate(encoded_auth_secrets):
+                colon_split_secret = secret.split(':')
+
+                if len(colon_split_secret) == 1:
+                #user did not provide an identifier, use index as an identifier
+                    identifier = str(encoded_auth_count) 
+                    secret = colon_split_secret[0]
+                else:
+                    identifier = colon_split_secret[0].upper()
+                    identifier.strip()
+                    secret = colon_split_secret[1]
+                encoded_auth_list.append( start_block + '"' + identifier + '"')
+                encoded_auth_list.append(b32encode_each(secret, True)+ end_block) 
+            return start_block + ",".join(encoded_auth_list) + end_block
+
+        else:
+            for c in removechars:
+                strings = strings.replace(c,'')
+            strings.strip()
+            encoded_auth_list = []
+            decoded_auth_secrets = strings.split(',')
+            for  identifier, decoded_secret in zip(*[iter(decoded_auth_secrets)]*2):
+                identifier = identifier.replace('"', '')
+                encoded_secret = b32encode_each(decoded_secret, False)
+                if not identifier[0].isdigit():
+                    encoded_secret = identifier + ':' + encoded_secret
+                encoded_auth_list.append(encoded_secret)
+            return ",".join(encoded_auth_list)
 
 def tzget (cfg_offset, tz_set):
         offset = 0


### PR DESCRIPTION
…ld in user input is now SINGLE-ALPHABET-IDENTIFIER:TOTP_KEY the SINGLE-ALPHABET-IDENTIFIER is optional and if user does not supply it the build system uses numeric identifiers such as 1,2,3...  are used, to cycle between keys press up/down buttons, the SINGLE-ALPHABET-IDENTIFIER is shown on the top lcd leftmost segment in a blinking fashion.

NB: config.h.circle may need to be regenerated since the format in which keys are stored has changed and is incompatible with the previous string-only format