### PR TITLE
remove default:false sections for Experimental modules, see https://goo.gl/zwHC3z

### DIFF
--- a/modules/accelerometer.cfg
+++ b/modules/accelerometer.cfg
@@ -1,5 +1,4 @@
 [ACCELEROMETER]
 menu_order = 70
 name = Accelerometer code [EXPERIMENTAL]
-default = false
 help = Provides accelerometer functions

--- a/modules/otp.cfg
+++ b/modules/otp.cfg
@@ -1,7 +1,6 @@
 [OTP]
 menu_order = 100
 name = Google OTP
-default = false
 help = Enable OTP generation
 depends = CONFIG_RTC_IRQ
 

--- a/modules/tide.cfg
+++ b/modules/tide.cfg
@@ -1,5 +1,4 @@
 [TIDE]
 menu_order = 90
 name = Tide [EXPERIMENTAL]
-default = false 
 help = a Tide Watch


### PR DESCRIPTION
having default:false causes configParser to enable 'bool' due to https://goo.gl/zwHC3z remove default:false for modules that are experimental